### PR TITLE
Fixing App Crash When Back Key Pressed During Animations

### DIFF
--- a/DrawableAnimations/app/src/main/java/com/example/android/drawableanimations/ViewBindingDelegates.kt
+++ b/DrawableAnimations/app/src/main/java/com/example/android/drawableanimations/ViewBindingDelegates.kt
@@ -16,14 +16,11 @@
 
 package com.example.android.drawableanimations
 
-import android.R
 import android.view.View
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.viewbinding.ViewBinding
-
 
 /**
  * Retrieves a view binding handle in a Fragment. The field is available only after
@@ -48,18 +45,12 @@ inline fun <reified BindingT : ViewBinding> Fragment.viewBindings(
             cached = null
         }
     }
-//    val mConstraintLayout: ConstraintLayout = findViewById(R.id.constraintLayoutParent)
- //   var layout: View = layoutInflater.inflate(R.layout.activity_list_item, null)
-//    override val value: BindingT
-//        get() = cached ?: bind(requireView()).also {
-//            viewLifecycleOwner.lifecycle.addObserver(observer)
-//            cached = it
-//        }
-override val value: BindingT
-    get() = cached ?: bind(requireView()).also {
-        viewLifecycleOwner.lifecycle.addObserver(observer)
-        cached = it
-    }
+
+    override val value: BindingT
+        get() = cached ?: bind(requireView()).also {
+            viewLifecycleOwner.lifecycle.addObserver(observer)
+            cached = it
+        }
 
     override fun isInitialized() = cached != null
 }

--- a/DrawableAnimations/app/src/main/java/com/example/android/drawableanimations/demo/animated/AnimatedFragment.kt
+++ b/DrawableAnimations/app/src/main/java/com/example/android/drawableanimations/demo/animated/AnimatedFragment.kt
@@ -27,6 +27,7 @@ import com.example.android.drawableanimations.databinding.AnimatedFragmentBindin
 import com.example.android.drawableanimations.viewBindings
 
 class AnimatedFragment : Fragment(R.layout.animated_fragment) {
+
     private val binding by viewBindings(AnimatedFragmentBinding::bind)
 
     override fun onDestroyView() {
@@ -57,4 +58,3 @@ class AnimatedFragment : Fragment(R.layout.animated_fragment) {
         binding.stop.setOnClickListener { icon.stop() }
     }
 }
-


### PR DESCRIPTION
**Root-Cause**
The animated fragment is set to null after the animation is completed. When we press the back button , the view gets destroyed but the animated fragment which is bound to the view is still running. As a result of the animation running even after back button is pressed, once this running animation completes, it invokes callbacks which try to access the destroyed view and its objects like the start and stop buttons at this [place in the code](https://github.com/android/animation-samples/blob/main/DrawableAnimations/app/src/main/java/com/example/android/drawableanimations/demo/animated/AnimatedFragment.kt#L45-L46).

**Fix**
We will Unregister all the callbacks for the components in the FragmentView when view is getting destroyed.
This should prevent any illegal callback invocation after view is destroyed. 

This fix is done on **both** ``AnimatedFragment.kt`` and ``SeekableFragment.kt`` as they both have this **bug**

This is the clip which shows the changes 👇

https://user-images.githubusercontent.com/74366348/131028772-f5eb54a2-6fed-4a61-9d56-968a1a3acacb.mp4



Tagging @yaraki for help for reviewing. Please review and merge the newer pull-request.

Thank You!
