### PR TITLE
Added AnimatedVisibilityExample.kt to MotionCompose

### DIFF
--- a/MotionCompose/app/src/main/java/com/example/android/compose/motion/demo/Demo.kt
+++ b/MotionCompose/app/src/main/java/com/example/android/compose/motion/demo/Demo.kt
@@ -22,6 +22,7 @@ import com.example.android.compose.motion.demo.fadethrough.FadeThroughDemo
 import com.example.android.compose.motion.demo.loading.LoadingDemo
 import com.example.android.compose.motion.demo.sharedaxis.SharedAxisDemo
 import com.example.android.compose.motion.demo.sharedtransform.SharedTransformDemo
+import com.example.android.compose.motion.demo.visibility.AnimatedVisibilityExample
 
 enum class Demo(
     val title: String,
@@ -82,7 +83,14 @@ enum class Demo(
         ),
         content = { SharedAxisDemo() }
     ),
-
+    AnimatedVisibility(
+        title = "Layout > Animating a view's visibility",
+        description = """
+            Animating the views visibility from visible to invisible
+        """.trimIndent(),
+        apis = listOf("AnimatedVisibility"),
+        content = { AnimatedVisibilityExample() }
+    ),
     Loading(
         title = "List > Loading",
         description = """

--- a/MotionCompose/app/src/main/java/com/example/android/compose/motion/demo/visibility/AnimatedVisibilityExample.kt
+++ b/MotionCompose/app/src/main/java/com/example/android/compose/motion/demo/visibility/AnimatedVisibilityExample.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.example.android.compose.motion.demo.visibility
 
 import androidx.compose.animation.AnimatedVisibility

--- a/MotionCompose/app/src/main/java/com/example/android/compose/motion/demo/visibility/AnimatedVisibilityExample.kt
+++ b/MotionCompose/app/src/main/java/com/example/android/compose/motion/demo/visibility/AnimatedVisibilityExample.kt
@@ -1,0 +1,58 @@
+package com.example.android.compose.motion.demo.visibility
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.android.compose.motion.demo.CheeseImages
+
+@Preview
+@Composable
+fun AnimatedVisibilityExample() {
+    var visible by remember {
+        mutableStateOf(true)
+    }
+    Box(modifier = Modifier.fillMaxSize()) {
+        AnimatedVisibility(visible,
+            modifier = Modifier.align(Alignment.Center),
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            Image(
+                painter = painterResource(id = CheeseImages[0]),
+                contentDescription = "Cheese",
+                modifier = Modifier
+                    .size(256.dp, 192.dp)
+                    .clip(shape = RoundedCornerShape(16.dp)),
+                contentScale = ContentScale.Crop
+            )
+        }
+        Button(
+            onClick = { visible = !visible },
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(64.dp)
+        ) {
+            Text(text = "TOGGLE VISIBILITY")
+        }
+    }
+}


### PR DESCRIPTION
Added AnimatedVisibility Sample to MotionCompose to demonstrate Animation Preview tooling. 


https://user-images.githubusercontent.com/9973046/175513421-1e804730-e909-4956-9c36-9f0899670fc4.mov

