### PR TITLE
Fix nullability of Menu in onCreateOptionsMenu

### DIFF
--- a/Motion/app/src/main/java/com/example/android/motion/demo/loading/LoadingActivity.kt
+++ b/Motion/app/src/main/java/com/example/android/motion/demo/loading/LoadingActivity.kt
@@ -87,7 +87,7 @@ class LoadingActivity : AppCompatActivity() {
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.loading, menu)
         return super.onCreateOptionsMenu(menu)
     }

--- a/Motion/app/src/main/java/com/example/android/motion/demo/stagger/StaggerActivity.kt
+++ b/Motion/app/src/main/java/com/example/android/motion/demo/stagger/StaggerActivity.kt
@@ -77,7 +77,7 @@ class StaggerActivity : AppCompatActivity() {
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.stagger, menu)
         return super.onCreateOptionsMenu(menu)
     }


### PR DESCRIPTION
... override of LoadingActivity and StaggerActivity.

The parameter should be non null, but the current override type is Menu?

Having an incorrect nullability causes compilation errors once the navigation dependency is updated to 2.5.0.